### PR TITLE
add onTabComplete for tab complete event

### DIFF
--- a/javasrc/com/supermomonga/rukkit/JRubyPlugin.java
+++ b/javasrc/com/supermomonga/rukkit/JRubyPlugin.java
@@ -407,7 +407,7 @@ public class JRubyPlugin extends JavaPlugin {
   }
 
   // XXX: work around, javassist cannot handle enclosing private method
-  void fireEvent(String method, Object...args) {
+  Object fireEvent(String method, Object...args) {
     final RubyEnvironment env = jruby.get();
     checkState(env != null);
 
@@ -418,7 +418,7 @@ public class JRubyPlugin extends JavaPlugin {
       rubyArgs.add(arg);
     }
 
-    env.callMethod(env.getCoreModule(), "fire_event", rubyArgs.toArray());
+    return env.callMethod(env.getCoreModule(), "fire_event", rubyArgs.toArray());
   }
 
   private void applyEventHandler() {
@@ -460,6 +460,11 @@ public class JRubyPlugin extends JavaPlugin {
   public boolean onCommand(org.bukkit.command.CommandSender sender, org.bukkit.command.Command command, String label, String[] args) {
     fireEvent("on_command", sender, command, label, args);
     return true;
+  }
+
+  @Override
+  public List<String> onTabComplete(org.bukkit.command.CommandSender sender, org.bukkit.command.Command command, String alias, String[] args) {
+    return fireEvent("on_tab_complete", sender, command, alias, args);
   }
 
   @Override


### PR DESCRIPTION
onCommandはあるけど、onTabCompleteがないので追加しました。
あってるかな？

\# onCommandの際に、一律trueを返してるのは何でなんだろう？false返すとエラー吐いてうっとおしいからかな？