### PR TITLE
return event result for tab complete

### DIFF
--- a/javasrc/scripts/core.rb
+++ b/javasrc/scripts/core.rb
@@ -151,12 +151,13 @@ module Rukkit
       end
 
       def fire_event(event, *args)
-        @@eventhandlers.each do |eventhandler|
-          if eventhandler.respond_to? event
-            # log.info "event: #{eventhandler}.#{event}"
-            eventhandler.send event, *args
-          end
-        end
+        results = @@eventhandlers.select { |eventhandler|
+          eventhandler.respond_to? event
+        }.map { |eventhandler|
+          # log.info "event: #{eventhandler}.#{event}"
+          eventhandler.send event, *args
+        }
+        results ? results.flatten.compact.uniq : nil
       end
     end
   end


### PR DESCRIPTION
tab completeのエラー問題を対応しました。

【原因】
event発火時に実行されるcore.rbのfire_eventメソッドの戻り値が、各pluginが処理したイベントの結果ではなく、各pluginのオブジェクトだったことです。
このため、JRubyPlugin.java側のonTabComplete側の処理で型が合わなくてエラーになっていました。

【対策】
core.rbのfire_eventのメソッドの戻り値を、各pluginが処理したイベントの結果の配列にしました。
また、on_tab_completeがそれぞれ結果として配列を返すため、イベントの処理結果の配列を平坦化してJava側で処理が楽になるようにしました。
\# 本当はここはJava側でやったほうがいいような気もしますが、面倒なのと、このケースon_tab_completeだけっぽいのでRuby側で対応しちゃいました。

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/supermomonga/rukkit/30)
<!-- Reviewable:end -->
